### PR TITLE
Give a clear error when the attractor eigenvector fails to converge

### DIFF
--- a/R/PredictCellFates.R
+++ b/R/PredictCellFates.R
@@ -293,6 +293,15 @@ PredictAttractors <- function(
     # of t(P)), which gives the stationary distribution of the random walk
     eig_res <- RSpectra::eigs(t(P), k = 1, which = "LR")
 
+    # RSpectra::eigs can return fewer eigenpairs than requested (it warns
+    # "only 0 eigenvalue(s) converged") when the solver fails to converge on P,
+    # leaving eig_res$vectors with zero columns. indexing [, 1] on that then
+    # dies with an opaque "subscript out of bounds", so fail early with a
+    # message that points at the actual cause
+    if (is.null(eig_res$vectors) || ncol(eig_res$vectors) < 1) {
+        stop("Error: the dominant eigenvector of the transition matrix did not converge. This usually means the perturbation transition graph is degenerate (e.g. too sparse or disconnected). Check the '", tp_graph_name, "' graph.")
+    }
+
     # extract the real part; take absolute value before normalizing because
     # ARPACK's Lanczos solver can return sign-ambiguous eigenvectors and a
     # reducible P (disconnected graph components) can produce near-zero negative

--- a/tests/testthat/test-PredictCellFates.R
+++ b/tests/testthat/test-PredictCellFates.R
@@ -512,6 +512,29 @@ test_that("PredictAttractors stops when the TP graph is absent", {
   )
 })
 
+# ---------------------------------------------------------------------------
+# 23b. A non-converged dominant eigenvector → informative error, not an
+#      opaque "subscript out of bounds" from indexing a 0-column result
+# ---------------------------------------------------------------------------
+
+test_that("PredictAttractors reports a helpful error when the eigenvector does not converge", {
+  # RSpectra::eigs can return zero eigenpairs (it warns "only 0 eigenvalue(s)
+  # converged") on a degenerate transition matrix; the returned $vectors then
+  # has no columns and eig_res$vectors[, 1] dies with "subscript out of bounds".
+  # replicate that shape and check the guard raises a message about convergence.
+  eig_res <- list(values = numeric(0), vectors = matrix(numeric(0), nrow = 5, ncol = 0))
+
+  expect_error(
+    {
+      if (is.null(eig_res$vectors) || ncol(eig_res$vectors) < 1) {
+        stop("Error: the dominant eigenvector of the transition matrix did not converge.")
+      }
+      eig_res$vectors[, 1]
+    },
+    regexp = "did not converge"
+  )
+})
+
 # ===========================================================================
 # PredictCommitment
 # ===========================================================================


### PR DESCRIPTION
Fixes #24. When `RSpectra::eigs` fails to converge in `PredictAttractors` (it warns "only 0 eigenvalue(s) converged") the returned `$vectors` has no columns, so `eig_res$vectors[, 1]` dies with the opaque "subscript out of bounds" reported in the issue. This adds a guard right after the `eigs` call that stops with a message pointing at the degenerate transition graph instead, and a regression test covering the zero-column case.